### PR TITLE
FIX: fix UART reception logic

### DIFF
--- a/workspace/bsp/bearlyml/src/bearlyml_hal_uart.c
+++ b/workspace/bsp/bearlyml/src/bearlyml_hal_uart.c
@@ -31,11 +31,13 @@ void HAL_UART_init(UART_TypeDef *UARTx, UART_InitTypeDef *UART_init) {
 }
 
 Status HAL_UART_receive(UART_TypeDef *UARTx, uint8_t *data, uint16_t size, uint32_t timeout) {
+  uint32_t rx_data_status;
   while (size > 0) {
-    while (READ_BITS(UARTx->RXDATA, UART_RXDATA_EMPTY_MSK)) {
+    rx_data_status = READ_BITS(UARTx->RXDATA, UART_RXDATA_EMPTY_MSK);
+    while (READ_BITS(rx_data_status, UART_RXDATA_EMPTY_MSK)) {
       // return TIMEOUT;
     }
-    *data = UARTx->RXDATA;
+    *data = READ_BITS(rx_data_status, UART_RXDATA_DATA_MSK);
     data += sizeof(uint8_t);
     size -= 1;
   }

--- a/workspace/bsp/bearlyml/src/bearlyml_hal_uart.c
+++ b/workspace/bsp/bearlyml/src/bearlyml_hal_uart.c
@@ -33,8 +33,9 @@ void HAL_UART_init(UART_TypeDef *UARTx, UART_InitTypeDef *UART_init) {
 Status HAL_UART_receive(UART_TypeDef *UARTx, uint8_t *data, uint16_t size, uint32_t timeout) {
   uint32_t rx_data_status;
   while (size > 0) {
-    rx_data_status = READ_BITS(UARTx->RXDATA, UART_RXDATA_EMPTY_MSK);
+    rx_data_status = UARTx->RXDATA;
     while (READ_BITS(rx_data_status, UART_RXDATA_EMPTY_MSK)) {
+      rx_data_status = UARTx->RXDATA;
       // return TIMEOUT;
     }
     *data = READ_BITS(rx_data_status, UART_RXDATA_DATA_MSK);

--- a/workspace/bsp/examplechip/src/examplechip_hal_uart.c
+++ b/workspace/bsp/examplechip/src/examplechip_hal_uart.c
@@ -31,11 +31,13 @@ void HAL_UART_init(UART_TypeDef *UARTx, UART_InitTypeDef *UART_init) {
 }
 
 Status HAL_UART_receive(UART_TypeDef *UARTx, uint8_t *data, uint16_t size, uint32_t timeout) {
+  uint32_t rx_data_status;
   while (size > 0) {
-    while (READ_BITS(UARTx->RXDATA, UART_RXDATA_EMPTY_MSK)) {
+    rx_data_status = READ_BITS(UARTx->RXDATA, UART_RXDATA_EMPTY_MSK);
+    while (READ_BITS(rx_data_status, UART_RXDATA_EMPTY_MSK)) {
       // return TIMEOUT;
     }
-    *data = UARTx->RXDATA;
+    *data = READ_BITS(rx_data_status, UART_RXDATA_DATA_MSK);
     data += sizeof(uint8_t);
     size -= 1;
   }

--- a/workspace/bsp/examplechip/src/examplechip_hal_uart.c
+++ b/workspace/bsp/examplechip/src/examplechip_hal_uart.c
@@ -33,8 +33,9 @@ void HAL_UART_init(UART_TypeDef *UARTx, UART_InitTypeDef *UART_init) {
 Status HAL_UART_receive(UART_TypeDef *UARTx, uint8_t *data, uint16_t size, uint32_t timeout) {
   uint32_t rx_data_status;
   while (size > 0) {
-    rx_data_status = READ_BITS(UARTx->RXDATA, UART_RXDATA_EMPTY_MSK);
+    rx_data_status = UARTx->RXDATA;
     while (READ_BITS(rx_data_status, UART_RXDATA_EMPTY_MSK)) {
+      rx_data_status = UARTx->RXDATA;
       // return TIMEOUT;
     }
     *data = READ_BITS(rx_data_status, UART_RXDATA_DATA_MSK);


### PR DESCRIPTION
This addresses Issue #1.

The logic now is fixed which it only reads from the RX_DATA register once for flag checking and data reception.