### PR TITLE
FIX: enable cast warnings, update BSP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ ARCHFLAGS = -march=$(ARCH) -mabi=$(ABI) -mcmodel=$(CODEMODEL) -fno-pie
 # compiler Flags
 CFLAGS  = -g -std=gnu11 -O0
 CFLAGS += -fno-common -fno-builtin-printf
-CFLAGS += -Wall -Wextra -Warray-bounds -Wno-unused-parameter
+CFLAGS += -Wall -Wextra -Warray-bounds -Wno-unused-parameter -Wcast-qual
 # CFLAGS += -Wl,--start-group -lc_nano -lgloss_htif -Wl,--end-group -lgcc
 CFLAGS += $(SPECFLAGS)
 CFLAGS += $(ARCHFLAGS)

--- a/core/src/syscalls.c
+++ b/core/src/syscalls.c
@@ -1,7 +1,7 @@
 #include "syscalls.h"
 
 ssize_t _write(int fd, const void *ptr, size_t len) {
-  HAL_UART_transmit(UART0, (uint8_t *)ptr, len, 100);
+  HAL_UART_transmit(UART0, (const uint8_t *)ptr, len, 100);
   return 0;
 }
 


### PR DESCRIPTION
Change UART send to cast to const pointer to match changed types in BSP