### PR TITLE
ADD: port FreeRTOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 build/
 *.log
 *.afdo
-*.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ option(PROF_COV                     "Build with profiling and coverage"       OF
 option(GCNO_ONLY                    "Only build gcno files"                   OFF )
 option(USE_PGO                      "Build with profile guided optimization"  OFF )
 option(OPT_INFO                     "Build with optimization information"      OFF )
+
+option(USE_FREERTOS                 "Build with FreeRTOS"                     OFF )
 # Define the variable with a default empty value
 set(AFDO_PATH "" CACHE STRING "Path to autofdo profile data")
 #################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,10 +134,6 @@ add_executable(app
 
 target_include_directories(app PUBLIC app/include)
 
-# add std lib path
-include_directories(/scratch/iansseijelly/chipyard/.conda-env/riscv-tools/riscv64-unknown-elf/include)
-link_directories(/scratch/iansseijelly/chipyard/.conda-env/riscv-tools/riscv64-unknown-elf/lib)
-
 #################################
 # Dependencies
 #################################

--- a/driver/rocket-chip/l_trace_encoder/l_trace_encoder.c
+++ b/driver/rocket-chip/l_trace_encoder/l_trace_encoder.c
@@ -7,7 +7,7 @@ void l_trace_sink_dma_configure_addr(LTraceSinkDmaType *sink_dma, uint64_t dma_a
 void l_trace_sink_dma_read(LTraceSinkDmaType *sink_dma, uint8_t *buffer) {
   sink_dma->TR_SK_DMA_FLUSH = 1;
   while (sink_dma->TR_SK_DMA_FLUSH_DONE == 0) {
-    ;
+    // printf("waiting for flush done\n");
   }
   // printf("[l_trace_sink_dma_read] flush done\n");
   uint64_t count = sink_dma->TR_SK_DMA_COUNT;

--- a/driver/rocket-chip/l_trace_encoder/l_trace_encoder.h
+++ b/driver/rocket-chip/l_trace_encoder/l_trace_encoder.h
@@ -7,17 +7,19 @@
 #include "rocketcore.h"
 
 typedef struct {
-  uint32_t TR_TE_CTRL;
-  uint32_t TR_TE_TARGET;
-  uint32_t TR_TE_HPM_COUNTER;
-  uint32_t TR_TE_HPM_TIME;
+  __IO uint32_t TR_TE_CTRL; //0x00
+  __I uint32_t TR_TE_INFO; //0x04
+  __IO uint32_t TR_TE_BUBBLE[6]; //0x08-0x1C
+  __IO uint32_t TR_TE_TARGET; //0x20
+  __IO uint32_t TR_TE_HPM_COUNTER; //0x24
+  __IO uint32_t TR_TE_HPM_TIME; //0x28
 } LTraceEncoderType;
 
 typedef struct {
-  uint32_t TR_SK_DMA_FLUSH;
-  uint32_t TR_SK_DMA_FLUSH_DONE;
-  uint64_t TR_SK_DMA_ADDR;
-  uint64_t TR_SK_DMA_COUNT;
+  __IO uint32_t TR_SK_DMA_FLUSH;
+  __I uint32_t TR_SK_DMA_FLUSH_DONE;
+  __IO uint64_t TR_SK_DMA_ADDR;
+  __I uint64_t TR_SK_DMA_COUNT;
 } LTraceSinkDmaType;
 
 #define TARGET_PRINT 0x0

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(blinky)
 add_subdirectory(embench)
 add_subdirectory(pmu-tests)
+add_subdirectory(freertos)

--- a/examples/freertos/CMakeLists.txt
+++ b/examples/freertos/CMakeLists.txt
@@ -1,0 +1,44 @@
+if (USE_FREERTOS)
+
+  include(FetchContent)
+
+  FetchContent_Declare( freertos_kernel
+    GIT_REPOSITORY https://github.com/FreeRTOS/FreeRTOS-Kernel.git
+    GIT_TAG        V11.1.0
+  )
+
+  add_library(freertos_config INTERFACE)
+
+  target_include_directories(freertos_config SYSTEM
+  INTERFACE
+      include
+  )
+
+  target_compile_definitions(freertos_config
+    INTERFACE
+      projCOVERAGE_TEST=0
+  )
+
+  set( FREERTOS_HEAP "4" CACHE STRING "" FORCE)
+  # Select the native compile PORT
+  set( FREERTOS_PORT "GCC_RISC_V" CACHE STRING "" FORCE)
+
+  FetchContent_MakeAvailable(freertos_kernel)
+
+  add_executable(freertos_demo src/main.c src/main_blinky.c src/riscv-virt.c)
+
+  target_include_directories(freertos_demo PRIVATE
+    ${freertos_kernel_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/config  # For FreeRTOSConfig.h
+  )
+
+  target_link_libraries(freertos_demo
+    PUBLIC freertos_kernel freertos_config
+    PUBLIC chip-config
+  )
+
+  target_link_libraries(freertos_demo PRIVATE 
+    -L${CMAKE_BINARY_DIR}/glossy -Wl,--whole-archive glossy -Wl,--no-whole-archive
+  )
+  
+endif()

--- a/examples/freertos/CMakeLists.txt
+++ b/examples/freertos/CMakeLists.txt
@@ -35,6 +35,7 @@ if (USE_FREERTOS)
   target_link_libraries(freertos_demo
     PUBLIC freertos_kernel freertos_config
     PUBLIC chip-config
+    PUBLIC l_trace_encoder
   )
 
   target_link_libraries(freertos_demo PRIVATE 

--- a/examples/freertos/include/FreeRTOSConfig.h
+++ b/examples/freertos/include/FreeRTOSConfig.h
@@ -1,0 +1,103 @@
+/*
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef FREERTOS_CONFIG_H
+#define FREERTOS_CONFIG_H
+
+#include "riscv-virt.h"
+
+/*-----------------------------------------------------------
+ * Application specific definitions.
+ *
+ * These definitions should be adjusted for your particular hardware and
+ * application requirements.
+ *
+ * THESE PARAMETERS ARE DESCRIBED WITHIN THE 'CONFIGURATION' SECTION OF THE
+ * FreeRTOS API DOCUMENTATION AVAILABLE ON THE FreeRTOS.org WEB SITE.
+ *
+ * See http://www.freertos.org/a00110.html.
+ *----------------------------------------------------------*/
+
+/* See https://www.freertos.org/Using-FreeRTOS-on-RISC-V.html */
+#define configMTIME_BASE_ADDRESS		( CLINT_ADDR + CLINT_MTIME )
+#define configMTIMECMP_BASE_ADDRESS		( CLINT_ADDR + CLINT_MTIMECMP )
+
+#define configUSE_PREEMPTION			1
+#define configUSE_IDLE_HOOK				0
+#define configUSE_TICK_HOOK				1
+#define configCPU_CLOCK_HZ				( 1000000 )
+#define configTICK_RATE_HZ				( ( TickType_t ) 10 )
+#define configMAX_PRIORITIES			( 7 )
+#define configMINIMAL_STACK_SIZE		( ( unsigned short ) 512 )
+#define configTOTAL_HEAP_SIZE			( ( size_t ) 64500 )
+#define configMAX_TASK_NAME_LEN			( 16 )
+#define configUSE_TRACE_FACILITY		0
+#define configUSE_16_BIT_TICKS			0
+#define configIDLE_SHOULD_YIELD			0
+#define configUSE_MUTEXES				1
+#define configQUEUE_REGISTRY_SIZE		8
+#define configCHECK_FOR_STACK_OVERFLOW	2
+#define configUSE_RECURSIVE_MUTEXES		1
+#define configUSE_MALLOC_FAILED_HOOK	1
+#define configUSE_APPLICATION_TASK_TAG	0
+#define configUSE_COUNTING_SEMAPHORES	1
+#define configGENERATE_RUN_TIME_STATS	0
+#define configUSE_PORT_OPTIMISED_TASK_SELECTION 1
+
+/* Co-routine definitions. */
+#define configUSE_CO_ROUTINES 			0
+#define configMAX_CO_ROUTINE_PRIORITIES ( 2 )
+
+/* Software timer definitions. */
+#define configUSE_TIMERS				1
+#define configTIMER_TASK_PRIORITY		( configMAX_PRIORITIES - 1 )
+#define configTIMER_QUEUE_LENGTH		6
+#define configTIMER_TASK_STACK_DEPTH	( 110 )
+
+/* RISC-V definitions. */
+#define configISR_STACK_SIZE_WORDS		2048
+
+/* Task priorities.  Allow these to be overridden. */
+#ifndef uartPRIMARY_PRIORITY
+	#define uartPRIMARY_PRIORITY		( configMAX_PRIORITIES - 3 )
+#endif
+
+/* Set the following definitions to 1 to include the API function, or zero
+to exclude the API function. */
+#define INCLUDE_vTaskPrioritySet			1
+#define INCLUDE_uxTaskPriorityGet			1
+#define INCLUDE_vTaskDelete					1
+#define INCLUDE_vTaskCleanUpResources		1
+#define INCLUDE_vTaskSuspend				1
+#define INCLUDE_vTaskDelayUntil				1
+#define INCLUDE_vTaskDelay					1
+#define INCLUDE_eTaskGetState				1
+#define INCLUDE_xTimerPendFunctionCall		1
+#define INCLUDE_xTaskAbortDelay				1
+#define INCLUDE_xTaskGetHandle				1
+#define INCLUDE_xSemaphoreGetMutexHolder	1
+
+#endif /* FREERTOS_CONFIG_H */

--- a/examples/freertos/include/FreeRTOSConfig.h
+++ b/examples/freertos/include/FreeRTOSConfig.h
@@ -48,8 +48,8 @@
 #define configUSE_PREEMPTION			1
 #define configUSE_IDLE_HOOK				0
 #define configUSE_TICK_HOOK				1
-#define configCPU_CLOCK_HZ				( 1000000 )
-#define configTICK_RATE_HZ				( ( TickType_t ) 10 )
+#define configCPU_CLOCK_HZ				( 1000000000 )
+#define configTICK_RATE_HZ				( ( TickType_t ) 1000 )
 #define configMAX_PRIORITIES			( 7 )
 #define configMINIMAL_STACK_SIZE		( ( unsigned short ) 512 )
 #define configTOTAL_HEAP_SIZE			( ( size_t ) 64500 )

--- a/examples/freertos/include/FreeRTOSConfig.h
+++ b/examples/freertos/include/FreeRTOSConfig.h
@@ -49,7 +49,7 @@
 #define configUSE_IDLE_HOOK				0
 #define configUSE_TICK_HOOK				1
 #define configCPU_CLOCK_HZ				( 1000000000 )
-#define configTICK_RATE_HZ				( ( TickType_t ) 1000 )
+#define configTICK_RATE_HZ				( ( TickType_t ) 100000 )
 #define configMAX_PRIORITIES			( 7 )
 #define configMINIMAL_STACK_SIZE		( ( unsigned short ) 512 )
 #define configTOTAL_HEAP_SIZE			( ( size_t ) 64500 )

--- a/examples/freertos/include/riscv-reg.h
+++ b/examples/freertos/include/riscv-reg.h
@@ -1,0 +1,36 @@
+/*
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef RISCV_REG_H_
+#define RISCV_REG_H_
+
+// we only target 64-bit riscv
+#define REGSIZE		8
+#define REGSHIFT	3
+#define LOAD		ld
+#define STOR		sd
+
+#endif /* RISCV_REG_H_ */

--- a/examples/freertos/include/riscv-virt.h
+++ b/examples/freertos/include/riscv-virt.h
@@ -1,0 +1,52 @@
+/*
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef RISCV_VIRT_H_
+#define RISCV_VIRT_H_
+
+#include "riscv-reg.h"
+
+#ifdef __ASSEMBLER__
+#define CONS(NUM, TYPE)NUM
+#else
+#define CONS(NUM, TYPE)NUM##TYPE
+#endif /* __ASSEMBLER__ */
+
+#define PRIM_HART			0
+
+#define CLINT_ADDR			CONS(0x02000000, UL)
+#define CLINT_MSIP			CONS(0x0000, UL)
+#define CLINT_MTIMECMP		CONS(0x4000, UL)
+#define CLINT_MTIME			CONS(0xbff8, UL)
+
+#ifndef __ASSEMBLER__
+
+int xGetCoreID( void );
+void vSendString( const char * s );
+
+#endif /* __ASSEMBLER__ */
+
+#endif /* RISCV_VIRT_H_ */

--- a/examples/freertos/src/main.c
+++ b/examples/freertos/src/main.c
@@ -1,0 +1,139 @@
+/*
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* FreeRTOS kernel includes. */
+#include <FreeRTOS.h>
+#include <task.h>
+
+/* Run a simple demo just prints 'Blink' */
+#define DEMO_BLINKY    1
+
+extern void freertos_risc_v_trap_handler( void );
+
+void vApplicationMallocFailedHook( void );
+void vApplicationIdleHook( void );
+void vApplicationStackOverflowHook( TaskHandle_t pxTask,
+                                    char * pcTaskName );
+void vApplicationTickHook( void );
+
+/*
+ * Setup the Spike simulator to run this demo.
+ */
+static void prvSetupSpike( void );
+
+int main_blinky( void );
+
+/*-----------------------------------------------------------*/
+
+int main( void )
+{
+    int ret;
+
+    prvSetupSpike();
+
+    #if defined( DEMO_BLINKY )
+        ret = main_blinky();
+    #else
+    #error "Please add or select demo."
+    #endif
+
+    return ret;
+}
+/*-----------------------------------------------------------*/
+static void prvSetupSpike( void )
+{
+    __asm__ volatile ( "csrw mtvec, %0" : : "r" ( freertos_risc_v_trap_handler ) );
+}
+
+/*-----------------------------------------------------------*/
+
+void vApplicationMallocFailedHook( void )
+{
+    /* vApplicationMallocFailedHook() will only be called if
+     * configUSE_MALLOC_FAILED_HOOK is set to 1 in FreeRTOSConfig.h.  It is a hook
+     * function that will get called if a call to pvPortMalloc() fails.
+     * pvPortMalloc() is called internally by the kernel whenever a task, queue,
+     * timer or semaphore is created.  It is also called by various parts of the
+     * demo application.  If heap_1.c or heap_2.c are used, then the size of the
+     * heap available to pvPortMalloc() is defined by configTOTAL_HEAP_SIZE in
+     * FreeRTOSConfig.h, and the xPortGetFreeHeapSize() API function can be used
+     * to query the size of free heap space that remains (although it does not
+     * provide information on how the remaining heap might be fragmented). */
+    taskDISABLE_INTERRUPTS();
+
+    for( ; ; )
+    {
+    }
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationIdleHook( void )
+{
+    /* vApplicationIdleHook() will only be called if configUSE_IDLE_HOOK is set
+     * to 1 in FreeRTOSConfig.h.  It will be called on each iteration of the idle
+     * task.  It is essential that code added to this hook function never attempts
+     * to block in any way (for example, call xQueueReceive() with a block time
+     * specified, or call vTaskDelay()).  If the application makes use of the
+     * vTaskDelete() API function (as this demo application does) then it is also
+     * important that vApplicationIdleHook() is permitted to return to its calling
+     * function, because it is the responsibility of the idle task to clean up
+     * memory allocated by the kernel to any task that has since been deleted. */
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationStackOverflowHook( TaskHandle_t pxTask,
+                                    char * pcTaskName )
+{
+    ( void ) pcTaskName;
+    ( void ) pxTask;
+
+    /* Run time stack overflow checking is performed if
+     * configCHECK_FOR_STACK_OVERFLOW is defined to 1 or 2.  This hook
+     * function is called if a stack overflow is detected. */
+    taskDISABLE_INTERRUPTS();
+
+    for( ; ; )
+    {
+    }
+}
+/*-----------------------------------------------------------*/
+
+void vApplicationTickHook( void )
+{
+}
+/*-----------------------------------------------------------*/
+
+void vAssertCalled( void )
+{
+    volatile uint32_t ulSetTo1ToExitFunction = 0;
+
+    taskDISABLE_INTERRUPTS();
+
+    while( ulSetTo1ToExitFunction != 1 )
+    {
+        __asm volatile ( "NOP" );
+    }
+}

--- a/examples/freertos/src/main.c
+++ b/examples/freertos/src/main.c
@@ -27,6 +27,7 @@
 /* FreeRTOS kernel includes. */
 #include <FreeRTOS.h>
 #include <task.h>
+#include "l_trace_encoder.h"
 
 /* Run a simple demo just prints 'Blink' */
 #define DEMO_BLINKY    1
@@ -52,13 +53,23 @@ int main( void )
 {
     int ret;
 
+    printf("Hello, world from main!\n");
+
     prvSetupSpike();
+
+    // LTraceEncoderType *encoder = l_trace_encoder_get(get_hart_id());
+    // l_trace_encoder_configure_target(encoder, TARGET_PRINT);
+    // l_trace_encoder_start(encoder);
+
+    printf("Hello, world from main2!\n");
 
     #if defined( DEMO_BLINKY )
         ret = main_blinky();
     #else
     #error "Please add or select demo."
     #endif
+
+    // l_trace_encoder_stop(encoder);
 
     return ret;
 }

--- a/examples/freertos/src/main.c
+++ b/examples/freertos/src/main.c
@@ -32,6 +32,8 @@
 /* Run a simple demo just prints 'Blink' */
 #define DEMO_BLINKY    1
 
+#define USE_TRACE 1
+
 extern void freertos_risc_v_trap_handler( void );
 
 void vApplicationMallocFailedHook( void );
@@ -53,15 +55,12 @@ int main( void )
 {
     int ret;
 
-    printf("Hello, world from main!\n");
-
     prvSetupSpike();
-
-    // LTraceEncoderType *encoder = l_trace_encoder_get(get_hart_id());
-    // l_trace_encoder_configure_target(encoder, TARGET_PRINT);
-    // l_trace_encoder_start(encoder);
-
-    printf("Hello, world from main2!\n");
+    #ifdef USE_TRACE
+        LTraceEncoderType *encoder = l_trace_encoder_get(get_hart_id());
+        l_trace_encoder_configure_target(encoder, TARGET_PRINT);
+        l_trace_encoder_start(encoder);
+    #endif
 
     #if defined( DEMO_BLINKY )
         ret = main_blinky();
@@ -69,7 +68,9 @@ int main( void )
     #error "Please add or select demo."
     #endif
 
-    // l_trace_encoder_stop(encoder);
+    #ifdef USE_TRACE
+        l_trace_encoder_stop(encoder);
+    #endif
 
     return ret;
 }

--- a/examples/freertos/src/main_blinky.c
+++ b/examples/freertos/src/main_blinky.c
@@ -1,0 +1,137 @@
+/*
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/* FreeRTOS kernel includes. */
+#include <FreeRTOS.h>
+#include <task.h>
+#include <queue.h>
+
+#include <stdio.h>
+
+#include "riscv-virt.h"
+
+/* Priorities used by the tasks. */
+#define mainQUEUE_RECEIVE_TASK_PRIORITY    ( tskIDLE_PRIORITY + 2 )
+#define mainQUEUE_SEND_TASK_PRIORITY       ( tskIDLE_PRIORITY + 1 )
+
+/* The rate at which data is sent to the queue.  The 200ms value is converted
+ * to ticks using the pdMS_TO_TICKS() macro. */
+#define mainQUEUE_SEND_FREQUENCY_MS        pdMS_TO_TICKS( 1000 )
+
+/* The maximum number items the queue can hold.  The priority of the receiving
+ * task is above the priority of the sending task, so the receiving task will
+ * preempt the sending task and remove the queue items each time the sending task
+ * writes to the queue.  Therefore the queue will never have more than one item in
+ * it at any time, and even with a queue length of 1, the sending task will never
+ * find the queue full. */
+#define mainQUEUE_LENGTH                   ( 1 )
+
+/*-----------------------------------------------------------*/
+
+/* The queue used by both tasks. */
+static QueueHandle_t xQueue = NULL;
+
+/*-----------------------------------------------------------*/
+
+static void prvQueueSendTask( void * pvParameters )
+{
+    TickType_t xNextWakeTime;
+    unsigned long ulValueToSend = 0UL;
+
+    /* Remove compiler warning about unused parameter. */
+    ( void ) pvParameters;
+
+    /* Initialise xNextWakeTime - this only needs to be done once. */
+    xNextWakeTime = xTaskGetTickCount();
+
+    for( ; ; )
+    {
+        /* Place this task in the blocked state until it is time to run again. */
+        vTaskDelayUntil( &xNextWakeTime, mainQUEUE_SEND_FREQUENCY_MS );
+
+        ulValueToSend++;
+
+        char buf[ 40 ];
+        sprintf( buf, "%d: %s: send %ld", xGetCoreID(),
+                 pcTaskGetName( xTaskGetCurrentTaskHandle() ),
+                 ulValueToSend );
+        vSendString( buf );
+
+        /* 0 is used as the block time so the sending operation will not block -
+         * it shouldn't need to block as the queue should always be empty at
+         * this point in the code. */
+        xQueueSend( xQueue, &ulValueToSend, 0U );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvQueueReceiveTask( void * pvParameters )
+{
+    /* Remove compiler warning about unused parameter. */
+    ( void ) pvParameters;
+
+    for( ; ; )
+    {
+        unsigned long ulReceivedValue;
+
+        /* Wait until something arrives in the queue - this task will block
+         * indefinitely provided INCLUDE_vTaskSuspend is set to 1 in
+         * FreeRTOSConfig.h. */
+        xQueueReceive( xQueue, &ulReceivedValue, portMAX_DELAY );
+
+        /*  To get here something must have been received from the queue. */
+        char buf[ 40 ];
+        sprintf( buf, "%d: %s: received %ld", xGetCoreID(),
+                 pcTaskGetName( xTaskGetCurrentTaskHandle() ),
+                 ulReceivedValue );
+        vSendString( buf );
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+int main_blinky( void )
+{
+    vSendString( "Hello FreeRTOS!" );
+
+    /* Create the queue. */
+    xQueue = xQueueCreate( mainQUEUE_LENGTH, sizeof( unsigned long ) );
+
+    if( xQueue != NULL )
+    {
+        /* Start the two tasks as described in the comments at the top of this
+         * file. */
+        xTaskCreate( prvQueueReceiveTask, "Rx", configMINIMAL_STACK_SIZE * 2U, NULL,
+                     mainQUEUE_RECEIVE_TASK_PRIORITY, NULL );
+        xTaskCreate( prvQueueSendTask, "Tx", configMINIMAL_STACK_SIZE * 2U, NULL,
+                     mainQUEUE_SEND_TASK_PRIORITY, NULL );
+    }
+
+    vTaskStartScheduler();
+
+    return 0;
+}

--- a/examples/freertos/src/main_blinky.c
+++ b/examples/freertos/src/main_blinky.c
@@ -133,9 +133,7 @@ static void prvQueueReceiveTask( void * pvParameters )
 
 int main_blinky( void )
 {
-    printf("Hello, world from blinky!\n");
-
-    vSendString( "Hello FreeRTOS!" );
+    printf("mainQUEUE_SEND_FREQUENCY_MS in ticks: %d\n", mainQUEUE_SEND_FREQUENCY_MS);
 
     /* Create the queue. */
     xQueue = xQueueCreate( mainQUEUE_LENGTH, sizeof( unsigned long ) );

--- a/examples/freertos/src/main_blinky.c
+++ b/examples/freertos/src/main_blinky.c
@@ -39,7 +39,7 @@
 
 /* The rate at which data is sent to the queue.  The 200ms value is converted
  * to ticks using the pdMS_TO_TICKS() macro. */
-#define mainQUEUE_SEND_FREQUENCY_MS        pdMS_TO_TICKS( 1000 )
+#define mainQUEUE_SEND_FREQUENCY_MS        pdMS_TO_TICKS( 1 )
 
 /* The maximum number items the queue can hold.  The priority of the receiving
  * task is above the priority of the sending task, so the receiving task will
@@ -53,6 +53,10 @@
 
 /* The queue used by both tasks. */
 static QueueHandle_t xQueue = NULL;
+// static volatile BaseType_t xTasksCompleted = pdFALSE;
+
+// #define NUM_ITERS 10
+// static int iter_count = 0;
 
 /*-----------------------------------------------------------*/
 
@@ -84,6 +88,12 @@ static void prvQueueSendTask( void * pvParameters )
          * it shouldn't need to block as the queue should always be empty at
          * this point in the code. */
         xQueueSend( xQueue, &ulValueToSend, 0U );
+
+        // iter_count++;
+        // if (iter_count >= NUM_ITERS) {
+        //     xTasksCompleted = pdTRUE;
+        //     vTaskSuspend(NULL);
+        // }
     }
 }
 
@@ -109,13 +119,22 @@ static void prvQueueReceiveTask( void * pvParameters )
                  pcTaskGetName( xTaskGetCurrentTaskHandle() ),
                  ulReceivedValue );
         vSendString( buf );
+
+        // iter_count++;
+        // if (iter_count >= NUM_ITERS) {
+        //     xTasksCompleted = pdTRUE;
+        //     vTaskSuspend(NULL);
+        // }
     }
 }
 
 /*-----------------------------------------------------------*/
 
+
 int main_blinky( void )
 {
+    printf("Hello, world from blinky!\n");
+
     vSendString( "Hello FreeRTOS!" );
 
     /* Create the queue. */

--- a/examples/freertos/src/riscv-virt.c
+++ b/examples/freertos/src/riscv-virt.c
@@ -1,0 +1,68 @@
+/*
+ * FreeRTOS V202212.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#include <FreeRTOS.h>
+
+#include <string.h>
+
+#include "riscv-virt.h"
+#include "htif.h"
+
+int xGetCoreID( void )
+{
+	int id;
+
+	__asm ("csrr %0, mhartid" : "=r" ( id ) );
+
+	return id;
+}
+
+/* Use a debugger to set this to 0 if this binary was loaded through gdb instead
+ * of spike's ELF loader. HTIF only works if spike's ELF loader was used. */
+volatile int use_htif = 1;
+
+void vSendString( const char *s )
+{
+	portENTER_CRITICAL();
+
+	if (use_htif) {
+		while (*s) {
+      htif_syscall(0, (uintptr_t)s, 1, FESVR_write);
+			// htif_putc(*s);
+			s++;
+		}
+    htif_syscall(0, (uintptr_t)"\n", 1, FESVR_write);
+		// htif_putc('\n');
+	}
+
+	portEXIT_CRITICAL();
+}
+
+void handle_trap(void)
+{
+	while (1)
+		;
+}

--- a/examples/freertos/src/riscv-virt.c
+++ b/examples/freertos/src/riscv-virt.c
@@ -48,15 +48,18 @@ void vSendString( const char *s )
 {
 	portENTER_CRITICAL();
 
-	if (use_htif) {
-		while (*s) {
-      htif_syscall(0, (uintptr_t)s, 1, FESVR_write);
-			// htif_putc(*s);
-			s++;
-		}
-    htif_syscall(0, (uintptr_t)"\n", 1, FESVR_write);
-		// htif_putc('\n');
-	}
+	printf("%s\n", s);
+
+	// if (use_htif) {
+	// 	while (*s) {
+  //     htif_syscall(0, (uintptr_t)s, 1, FESVR_write);
+	// 		// htif_putc(*s);
+	// 		s++;
+	// 	}
+  //   htif_syscall(0, (uintptr_t)"\n", 1, FESVR_write);
+	// 	// htif_putc('\n');
+	// }
+	// htif_syscall(0, (uintptr_t)"\n", 1, FESVR_write);
 
 	portEXIT_CRITICAL();
 }

--- a/examples/pmu-tests/CMakeLists.txt
+++ b/examples/pmu-tests/CMakeLists.txt
@@ -13,7 +13,6 @@ foreach(test ${TESTS})
   add_executable(${test} src/${test}.c)
   target_link_libraries(${test} 
   PUBLIC l_trace_encoder 
-  PUBLIC mada_timer
   PRIVATE -L${CMAKE_BINARY_DIR}/glossy -Wl,--whole-archive glossy -Wl,--no-whole-archive
   PUBLIC m
   )

--- a/examples/pmu-tests/src/ltrace-dma-test.c
+++ b/examples/pmu-tests/src/ltrace-dma-test.c
@@ -2,12 +2,34 @@
 #include "riscv.h"
 #include "riscv_encoding.h"
 #include "l_trace_encoder.h"
-
-#define NUM_ITERS 100
-
+#include "math.h"
 #define USE_L_TRACE_DMA
-
 __attribute__((aligned(64), section(".noinit"))) static volatile uint8_t dma_buffer[512 * 1024];
+
+#define NUM_ITERS 60 // 0 to 2pi, 60 steps
+
+void FOC_invParkTransform(float *v_alpha, float *v_beta, float v_q, float v_d, float sin_theta, float cos_theta) {
+  *v_alpha  = -(sin_theta * v_q) + (cos_theta * v_d);
+  *v_beta   =  (cos_theta * v_q) + (sin_theta * v_d);
+}
+
+void FOC_invClarkSVPWM(float *v_a, float *v_b, float *v_c, float v_alpha, float v_beta) {
+  float v_a_phase = v_alpha;
+  float v_b_phase = (-.5f * v_alpha) + ((sqrtf(3.f)/2.f) * v_beta);
+  float v_c_phase = (-.5f * v_alpha) - ((sqrtf(3.f)/2.f) * v_beta);
+
+  float v_neutral = .5f * (fmaxf(fmaxf(v_a_phase, v_b_phase), v_c_phase) + fminf(fminf(v_a_phase, v_b_phase), v_c_phase));
+
+  *v_a = v_a_phase - v_neutral;
+  *v_b = v_b_phase - v_neutral;
+  *v_c = v_c_phase - v_neutral;
+}
+
+void FOC_update(float *v_a, float *v_b, float *v_c, float vq, float vd) {
+  float v_alpha, v_beta;
+  FOC_invParkTransform(&v_alpha, &v_beta, vq, vd, sin(vq), cos(vq));
+  FOC_invClarkSVPWM(v_a, v_b, v_c, v_alpha, v_beta);
+}
 
 int main(int argc, char **argv) {
   // 64 aligned
@@ -20,15 +42,24 @@ int main(int argc, char **argv) {
     l_trace_encoder_configure_target(encoder, TARGET_PRINT);
   #endif
   l_trace_encoder_start(encoder);
-  volatile int c;
-  // do some dummy loops
-  for (int i = 0; i < NUM_ITERS; i++) {
-    c += i;
+  for (int i = 0; i < 10; i++) {
+    __asm__("nop");
   }
-  // do some different loops
+
+  // warmup
+  // float v_a = 0, v_b = 0, v_c = 0;
+  // FOC_update(&v_a, &v_b, &v_c, 0, 0);
+  printf("Starting trace encoder\n");
+
   for (int i = 0; i < NUM_ITERS; i++) {
-    c -= i;
+    float vq = 2 * M_PI * i / NUM_ITERS;
+    float vd = 0;
+    volatile float v_a, v_b, v_c;
+    for (int j = 0; j < 2; j++) {
+      FOC_update(&v_a, &v_b, &v_c, vq, vd);
+    }
   }
+
   l_trace_encoder_stop(encoder);
   #ifdef USE_L_TRACE_DMA
     l_trace_sink_dma_read(sink_dma, dma_buffer);

--- a/examples/pmu-tests/src/vpp-test.c
+++ b/examples/pmu-tests/src/vpp-test.c
@@ -46,7 +46,7 @@ int main(int argc, char **argv) {
   for (int i = 0; i < NUM_ITERS; i++) {
     float vq = 2 * M_PI * i / NUM_ITERS;
     float vd = 0;
-    float v_alpha, v_beta, v_a, v_b, v_c;
+    volatile float v_a, v_b, v_c;
     for (int j = 0; j < 2; j++) {
       FOC_update(&v_a, &v_b, &v_c, vq, vd);
     }

--- a/examples/pmu-tests/src/vpp-test.c
+++ b/examples/pmu-tests/src/vpp-test.c
@@ -3,7 +3,7 @@
 #include "riscv_encoding.h"
 #include "l_trace_encoder.h"
 #include "math.h"
-#include "mada_timer.h"
+// #include "mada_timer.h"
 
 #define NUM_ITERS 60 // 0 to 2pi, 60 steps
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,2 +1,1 @@
 add_subdirectory(gcov)
-add_subdirectory(perf)

--- a/riscv-llvm.cmake
+++ b/riscv-llvm.cmake
@@ -35,3 +35,6 @@ set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
+# add std lib path
+include_directories("$ENV{RISCV}/riscv64-unknown-elf/include")
+link_directories("$ENV{RISCV}/riscv64-unknown-elf/lib")


### PR DESCRIPTION
This PR ports FreeRTOS to baremetal-IDE. 
Because it uses FetchContent (over adding it as a submodule directly), and fetchcontent is quite slow when building, a cmake option USE_FREERTOS is added to prevent elongating the build time when FreeRTOS is not required. 